### PR TITLE
[utils] Explicit error when GoogleCaptcha.

### DIFF
--- a/google/modules/utils.py
+++ b/google/modules/utils.py
@@ -38,8 +38,15 @@ def get_html(url):
             "User-Agent", "Mozilla/5.001 (windows; U; NT4.0; en-US; rv:1.0) Gecko/25250101")
         html = urllib2.urlopen(request).read()
         return html
-    except:
+    except urllib2.HTTPError as e:
         print "Error accessing:", url
+        if e.code == 503 and 'CaptchaRedirect' in e.read():
+            print "Google is requiring a Captcha. " \
+                  "For more information see: 'https://support.google.com/websearch/answer/86640'"
+        return None
+    except Exception as e:
+        print "Error accessing:", url
+        print e
         return None
 
 


### PR DESCRIPTION
Would for instance output in the case where google is asking for a captcha:
```python
>>> google.search('site:bleh.meh inurl:foo')
Error accessing: http://www.google.com/search?hl=en&q=site%3Ableh.meh+inurl%3Afoo&start=0&num=10
Google is requiring a Captcha. For more information see: 'https://support.google.com/websearch/answer/86640'
[]
```

A better fix would be to properly handle Google's captcha. For instance, opening the URL in the User's browser and ask him to answer it.