### PR TITLE
external link for standard search implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ search_results = google.search("This is my query", num_page)
 ```python
 GoogleResult:
     self.name # The title of the link
-    self.link # The external link (NOT implemented yet)
+    self.link # The external link
     self.google_link # The google link
     self.description # The description of the link
     self.thumb # The link to a thumbnail of the website (NOT implemented yet)

--- a/google/modules/standard_search.py
+++ b/google/modules/standard_search.py
@@ -3,7 +3,9 @@ from __future__ import unicode_literals
 from utils import _get_search_url, get_html
 from bs4 import BeautifulSoup
 import urlparse
+from urllib2 import unquote
 from unidecode import unidecode
+from re import match
 
 
 class GoogleResult:
@@ -98,11 +100,12 @@ def _get_link(li):
     a = li.find("a")
     link = a["href"]
 
-    if link.startswith("/url?") or link.startswith("/search?"):
-        return None
+    if link.startswith("/url?"):
+        m = match('/url\?(url|q)=(.+?)&', link)
+        if m and len(m.groups()) == 2:
+            return unquote(m.group(2))
 
-    else:
-        return link
+    return None
 
 
 def _get_google_link(li):


### PR DESCRIPTION
I've implemended external link extration from google link exactly how it is implemented in this greasemonkey script: 
https://greasyfork.org/en/scripts/1810-google-tracking-b-gone
(It works fine for years in my FF)