### PR TITLE
Removed the call to normalize_query() for searches.

### DIFF
--- a/google/modules/utils.py
+++ b/google/modules/utils.py
@@ -32,7 +32,7 @@ def _get_search_url(query, page=0, per_page=10, lang='en'):
     # note: num per page might not be supported by google anymore (because of
     # google instant)
 
-    params = {'nl': lang, 'q': normalize_query(query).encode('utf8'), 'start':page * per_page, 'num':per_page}
+    params = {'nl': lang, 'q': query.encode('utf8'), 'start':page * per_page, 'num':per_page}
     params = urlencode(params)
     url = u"http://www.google.com/search?" + params
     #return u"http://www.google.com/search?hl=%s&q=%s&start=%i&num=%i" % (lang, normalize_query(query), page * per_page, per_page)


### PR DESCRIPTION
In `_get_search_url()`, we removed the call to `normalize_query()` for the `q` parameter.
The normalization is already performed by `urllib.urlencode()` (L36). 
Example:
```python
>>> import urllib
>>> urllib.urlencode({"q": "a:b+c"})  
'q=a%3Ab%2Bc' # good value
>>> def normalize_query(query): return query.strip().replace(":", "%3A").replace("+", "%2B").replace("&", "%26").replace(" ", "+" )
>>> urllib.urlencode({"q": normalize_query("a:b+c")})
'q=a%253Ab%252Bc' # wrong value because characters like + or : were encoded twice.
```
This simple hack allows Google keywords (`site:`, `filetype:`, etc.) to work as expected.