### PR TITLE
Allow filtering image search by license

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ class ColorType:
     COLOR = "color"
     BLACK_WHITE = "gray"
     SPECIFIC = "specific"
+
+class License:
+    NONE = None
+    REUSE = "fc"
+    REUSE_WITH_MOD = "fmc"
+    REUSE_NON_COMMERCIAL = "f"
+    REUSE_WITH_MOD_NON_COMMERCIAL = "fm"
 ```
 
 You can download a list of images.

--- a/google/modules/images.py
+++ b/google/modules/images.py
@@ -62,6 +62,14 @@ class ColorType:
     SPECIFIC = "specific"
 
 
+class License:
+    NONE = None
+    REUSE = "fc"
+    REUSE_WITH_MOD = "fmc"
+    REUSE_NON_COMMERCIAL = "f"
+    REUSE_WITH_MOD_NON_COMMERCIAL = "fm"
+
+
 class ImageOptions:
 
     """Allows passing options to filter a google images search."""
@@ -74,6 +82,7 @@ class ImageOptions:
         self.exact_height = None
         self.color_type = None
         self.color = None
+        self.license = None
 
     def __repr__(self):
         return unidecode(self.__dict__)
@@ -100,6 +109,8 @@ class ImageOptions:
         if self.color:
             tbs = self._add_to_tbs(tbs, "ic", ColorType.SPECIFIC)
             tbs = self._add_to_tbs(tbs, "isc", self.color)
+        if self.license:
+            tbs = self._add_to_tbs(tbs, "sur", self.license)
         return tbs
 
     def _add_to_tbs(self, tbs, name, value):

--- a/google/tests/test_google.py
+++ b/google/tests/test_google.py
@@ -140,10 +140,11 @@ class SearchImagesTest(unittest.TestCase):
         options.image_type = images.ImageType.CLIPART
         options.larger_than = images.LargerThan.MP_4
         options.color = "green"
+        options.license = images.License.REUSE_WITH_MOD
 
         req_url = images._get_images_req_url(query, options)
 
-        exp_req_url = 'https://www.google.com.ar/search?q=banana&es_sm=122&source=lnms&tbm=isch&sa=X&ei=DDdUVL-fE4SpNq-ngPgK&ved=0CAgQ_AUoAQ&biw=1024&bih=719&dpr=1.25&tbs=itp:clipart,isz:lt,islt:4mp,ic:specific,isc:green'
+        exp_req_url = 'https://www.google.com.ar/search?q=banana&es_sm=122&source=lnms&tbm=isch&sa=X&ei=DDdUVL-fE4SpNq-ngPgK&ved=0CAgQ_AUoAQ&biw=1024&bih=719&dpr=1.25&tbs=itp:clipart,isz:lt,islt:4mp,ic:specific,isc:green,sur:fmc'
 
         self.assertEqual(req_url, exp_req_url)
 


### PR DESCRIPTION
Mentioned in docs and added to google image test. Uses the currently available options in google image search.