### PR TITLE
Fix ImageResult representation

### DIFF
--- a/google/modules/images.py
+++ b/google/modules/images.py
@@ -139,9 +139,12 @@ class ImageResult:
         return id(self.link)
 
     def __repr__(self):
-        string = "ImageResult(" + \
-                 "index={}, page={}, ".format(unidecode(self.index), unidecode(self.page)) + \
-                 "domain={}, link={})".format(unidecode(self.domain), unidecode(self.link))
+        string = "ImageResult(index={i}, page={p}, domain={d}, link={l})".format(
+            i=str(self.index),
+            p=str(self.page),
+            d=unidecode(self.domain) if self.domain else None,
+            l=unidecode(self.link) if self.link else None
+        )
         return string
 
     def download(self, path="images"):

--- a/google/tests/test_google.py
+++ b/google/tests/test_google.py
@@ -147,6 +147,18 @@ class SearchImagesTest(unittest.TestCase):
 
         self.assertEqual(req_url, exp_req_url)
 
+    def test_repr(self):
+        res = images.ImageResult()
+        assert repr(res) == 'ImageResult(index=None, page=None, domain=None, link=None)'
+        res.page = 1
+        res.index = 11
+        res.name = 'test'
+        res.thumb = 'test'
+        res.format = 'test'
+        res.domain = 'test'
+        res.link = 'http://aa.com'
+        assert repr(res) == 'ImageResult(index=11, page=1, domain=test, link=http://aa.com)'
+
     def test_download(self):
         pass
 


### PR DESCRIPTION
This should handle cases where result properties are not yet set (empty object) as well as normal result case where index/page integers could not be passed to `unidecode` directly