### PR TITLE
workaround for selenium==3.4.3 and geckodriver

### DIFF
--- a/google/modules/images.py
+++ b/google/modules/images.py
@@ -434,7 +434,7 @@ def search(query, image_options=None, num_images=50):
     results = set()
     curr_num_img = 1
     page = 0
-    browser = get_browser_with_url("")
+    browser = get_browser_with_url("about:home")
     while curr_num_img <= num_images:
 
         page += 1


### PR DESCRIPTION
Traceback (most recent call last):
  File "test.py", line 17, in <module>
    results = google.search_images("banana", options)
  File "/usr/local/lib/python2.7/dist-packages/google/modules/images.py", line 430, in search
    browser = get_browser_with_url("")
  File "/usr/local/lib/python2.7/dist-packages/google/modules/utils.py", line 86, in get_browser_with_url
    browser.get(url)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 268, in get
    self.execute(Command.GET, {'url': url})
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 256, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/errorhandler.py", line 194, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: Malformed URL:  is not a valid URL.
