### PR TITLE
Added support for searchs without country redirection

### DIFF
--- a/google/modules/standard_search.py
+++ b/google/modules/standard_search.py
@@ -50,7 +50,7 @@ class GoogleResult(object):
 
 
 # PUBLIC
-def search(query, pages=1, lang='en', ncr=True, void=True):
+def search(query, pages=1, lang='en', ncr=False, void=True):
     """Returns a list of GoogleResult.
 
     Args:

--- a/google/modules/standard_search.py
+++ b/google/modules/standard_search.py
@@ -50,7 +50,7 @@ class GoogleResult(object):
 
 
 # PUBLIC
-def search(query, pages=1, lang='en', void=True):
+def search(query, pages=1, lang='en', ncr=True, void=True):
     """Returns a list of GoogleResult.
 
     Args:
@@ -62,7 +62,7 @@ def search(query, pages=1, lang='en', void=True):
 
     results = []
     for i in range(pages):
-        url = _get_search_url(query, i, lang=lang)
+        url = _get_search_url(query, i, lang=lang, ncr=ncr)
         html = get_html(url)
 
         if html:
@@ -87,7 +87,6 @@ def search(query, pages=1, lang='en', void=True):
                         continue
                 results.append(res)
                 j += 1
-
     return results
 
 

--- a/google/modules/standard_search.py
+++ b/google/modules/standard_search.py
@@ -26,6 +26,7 @@ class GoogleResult(object):
         self.cached = None  # Cached version link of page
         self.page = None  # Results page this one was on
         self.index = None  # What index on this page it was on
+        self.number_of_results = None # The total number of results the query returned
 
     def __repr__(self):
         name = self._limit_str_size(self.name, 55)
@@ -57,6 +58,7 @@ def search(query, pages=1, lang='en', ncr=False, void=True):
         query: String to search in google.
         pages: Number of pages where results must be taken.
 
+    TODO: add support to get the google results.
     Returns:
         A GoogleResult object."""
 
@@ -68,6 +70,9 @@ def search(query, pages=1, lang='en', ncr=False, void=True):
         if html:
             soup = BeautifulSoup(html, "html.parser")
             divs = soup.findAll("div", attrs={"class": "g"})
+            results_div = soup.find("div", attrs={"id": "resultStats"})
+            results_text = results_div.get_text()
+            number_of_results = _get_number_of_results(results_text) if results_text else 0
 
             j = 0
             for li in divs:
@@ -82,6 +87,8 @@ def search(query, pages=1, lang='en', ncr=False, void=True):
                 res.description = _get_description(li)
                 res.thumb = _get_thumb()
                 res.cached = _get_cached(li)
+                res.number_of_results = number_of_results
+
                 if void is True:
                     if res.description is None:
                         continue
@@ -159,3 +166,13 @@ def _get_cached(li):
         if link.startswith("/url?") or link.startswith("/search?"):
             return urllib.parse.urljoin("http://www.google.com", link)
     return None
+
+def _get_number_of_results(results_div_text):
+    """Return the total number of results of a google search."""
+    if results_div_text:
+        regex = r"(?:About )?((?:\d+,)*\d+) results?"
+        m = match(regex, results_div_text)
+        results = int(m.groups()[0].replace(",",""))
+        return results
+    else:
+        return 0

--- a/google/modules/utils.py
+++ b/google/modules/utils.py
@@ -33,12 +33,19 @@ def normalize_query(query):
     return query.strip().replace(":", "%3A").replace("+", "%2B").replace("&", "%26").replace(" ", "+")
 
 
-def _get_search_url(query, page=0, per_page=10, lang='en'):
+def _get_search_url(query, page=0, per_page=10, lang='en', ncr=True):
     # note: num per page might not be supported by google anymore (because of
     # google instant)
 
     params = {'nl': lang, 'q': query.encode(
-        'utf8'), 'start': page * per_page, 'num': per_page}
+        'utf8'), 'start': page * per_page, 'num': per_page }
+
+    # This will allow to search Google with No Country Redirect
+    if ncr:
+        params['gl'] = 'us' # Geographic Location: US
+        params['pws'] = '0' # 'pws' = '0' disables personalised search
+        params['gws_rd'] = 'cr' # Google Web Server ReDirect: CountRy.
+
     params = urlencode(params)
     url = u"http://www.google.com/search?" + params
     # return u"http://www.google.com/search?hl=%s&q=%s&start=%i&num=%i" %

--- a/google/modules/utils.py
+++ b/google/modules/utils.py
@@ -12,7 +12,7 @@ import urllib.request, urllib.error, urllib.parse
 from functools import wraps
 # import requests
 from urllib.parse import urlencode
-
+import sys
 
 def measure_time(fn):
 
@@ -47,7 +47,15 @@ def _get_search_url(query, page=0, per_page=10, lang='en', ncr=False):
         params['gws_rd'] = 'cr' # Google Web Server ReDirect: CountRy.
 
     params = urlencode(params)
-    url = u"http://www.google.com/search?" + params
+
+    # Workaround to switch between http and https, since this way
+    # it seems to avoid the 503 error when performing a lot of queries. 
+    # Weird, but it works.
+    # You may also wanna wait some time between queries, say, randint(50,65)
+    # between each query, and randint(180,240) every 100 queries.
+    https = int(time.time()) % 2 == 0
+    bare_url = u"https://www.google.com/search?" if https else u"http://www.google.com/search?"
+    url = bare_url + params
     # return u"http://www.google.com/search?hl=%s&q=%s&start=%i&num=%i" %
     # (lang, normalize_query(query), page * per_page, per_page)
     return url
@@ -62,9 +70,8 @@ def get_html(url):
         return html
     except urllib.error.HTTPError as e:
         print("Error accessing:", url)
-        if e.code == 503 and 'CaptchaRedirect' in e.read():
-            print("Google is requiring a Captcha. " \
-                  "For more information see: 'https://support.google.com/websearch/answer/86640'")
+        if e.code == 503:
+            sys.exit("503 Error: service is currently unavailable. Program will exit.")
         return None
     except Exception as e:
         print("Error accessing:", url)

--- a/google/modules/utils.py
+++ b/google/modules/utils.py
@@ -33,7 +33,7 @@ def normalize_query(query):
     return query.strip().replace(":", "%3A").replace("+", "%2B").replace("&", "%26").replace(" ", "+")
 
 
-def _get_search_url(query, page=0, per_page=10, lang='en', ncr=True):
+def _get_search_url(query, page=0, per_page=10, lang='en', ncr=False):
     # note: num per page might not be supported by google anymore (because of
     # google instant)
 


### PR DESCRIPTION
When searching from, say, Argentina, you get different Google results than when searching from the United States.
This modification will allow users to search as if they were using Google.com even outside the US (formerly accesible via google.com/ncr), which is a pretty useful feature when your servers or your computer are in another country.

I added the boolean parameter `ncr` (set to True by default) to the functions **search** (from _standart_search.py_) and **_get_search_url** (from _utils.py_). 

When `ncr` is set to True, the following key/value pairs will be added to the `params` dictionary in __get_search_url_:

- 'gl': 'us' sets the Geographic Location to the US
- 'pws' = '0' disables personalised search
- 'gws_rd': 'cr' may stand for Google Web Server ReDirect: CountRy | Country Redirect

Also, this will solve issue #25.